### PR TITLE
Room editor improvements

### DIFF
--- a/RPGGame/GameObject/Entity.cs
+++ b/RPGGame/GameObject/Entity.cs
@@ -6,7 +6,7 @@ namespace RPGGame.GameObject
 {
     [Serializable]
     [JsonObject(MemberSerialization.OptIn)]
-    public class Entity(Vector2 position, Vector2 size)
+    public class Entity(Vector2 position, Vector2 size) : ICloneable
     {
         [JsonProperty]
         public Vector2 Position { get; protected set; } = position;
@@ -28,6 +28,11 @@ namespace RPGGame.GameObject
 
             Position = targetPos;
             return true;
+        }
+
+        public object Clone()
+        {
+            return new Entity(Position, Size);
         }
     }
 }

--- a/RPGGame/GameObject/Room.cs
+++ b/RPGGame/GameObject/Room.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.Xna.Framework;
 using Newtonsoft.Json;
 
@@ -6,7 +7,7 @@ namespace RPGGame.GameObject
 {
     [Serializable]
     [JsonObject(MemberSerialization.OptIn)]
-    public class Room(Tile[,] tileMap, Entity[] entities, Color backgroundColor)
+    public class Room(Tile[,] tileMap, Entity[] entities, Color backgroundColor) : ICloneable
     {
         [JsonProperty]
         public Tile[,] TileMap { get; protected set; } = tileMap;
@@ -14,5 +15,10 @@ namespace RPGGame.GameObject
         public Entity[] Entities { get; protected set; } = entities;
         [JsonProperty]
         public Color BackgroundColor { get; protected set; } = backgroundColor;
+
+        public object Clone()
+        {
+            return new Room((Tile[,])TileMap.Clone(), Entities.Select(e => (Entity)e.Clone()).ToArray(), BackgroundColor);
+        }
     }
 }

--- a/RPGLevelEditor/RoomEditor.xaml
+++ b/RPGLevelEditor/RoomEditor.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:RPGLevelEditor"
         mc:Ignorable="d"
-        Title="Room Editor" Height="450" Width="800" Closing="Window_Closing">
+        Title="Room Editor" Height="450" Width="800" Closing="Window_Closing" KeyDown="Window_KeyDown">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -15,6 +15,10 @@
         <Menu Grid.Row="0" Padding="0,0,0,3">
             <MenuItem Header="_File">
                 <MenuItem Header="_Save" Click="SaveItem_OnClick"/>
+            </MenuItem>
+            <MenuItem Header="_Edit">
+                <MenuItem x:Name="undoItem" Header="_Undo" InputGestureText="Ctrl+Z" Click="undoItem_OnClick"/>
+                <MenuItem x:Name="redoItem" Header="_Redo" InputGestureText="Ctrl+Y" Click="redoItem_OnClick"/>
             </MenuItem>
         </Menu>
         <TabControl Grid.Row="1">

--- a/RPGLevelEditor/RoomEditor.xaml
+++ b/RPGLevelEditor/RoomEditor.xaml
@@ -20,6 +20,9 @@
                 <MenuItem x:Name="undoItem" Header="_Undo" InputGestureText="Ctrl+Z" Click="undoItem_OnClick"/>
                 <MenuItem x:Name="redoItem" Header="_Redo" InputGestureText="Ctrl+Y" Click="redoItem_OnClick"/>
             </MenuItem>
+            <MenuItem Header="_View">
+                <MenuItem x:Name="gridOverlayItem" Header="_Show Grid Overlay" IsCheckable="True" Click="gridOverlayItem_OnClick"/>
+            </MenuItem>
         </Menu>
         <TabControl Grid.Row="1">
             <TabItem Header="Tile Map">

--- a/RPGLevelEditor/RoomEditor.xaml
+++ b/RPGLevelEditor/RoomEditor.xaml
@@ -10,6 +10,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="20*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Menu Grid.Row="0" Padding="0,0,0,3">
             <MenuItem Header="_File">
@@ -23,7 +24,7 @@
                         <ColumnDefinition Width="1*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <ScrollViewer x:Name="tileMapScroll" Grid.Column="0" HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" PreviewMouseWheel="tileMapScroll_PreviewMouseWheel">
+                    <ScrollViewer x:Name="tileMapScroll" Grid.Column="0" HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" PreviewMouseWheel="tileMapScroll_PreviewMouseWheel" MouseMove="tileMapScroll_MouseMove">
                         <Grid HorizontalAlignment="Center" VerticalAlignment="Center" Width="{Binding ActualWidth, ElementName=tileGridDisplay, Mode=OneWay}" Height="{Binding ActualHeight, ElementName=tileGridDisplay, Mode=OneWay}">
                             <Grid x:Name="tileGridDisplay"/>
                             <!-- Center point marker -->
@@ -43,5 +44,22 @@
                 </Grid>
             </TabItem>
         </TabControl>
+        <StatusBar Grid.Row="2">
+            <StatusBarItem>
+                <Label x:Name="mousePositionLabel" Content="Mouse: (0.00, 0.00)" Padding="0"/>
+            </StatusBarItem>
+            <Separator/>
+            <StatusBarItem>
+                <Label x:Name="gridPositionLabel" Content="Grid: (0, 0)" Padding="0"/>
+            </StatusBarItem>
+            <Separator/>
+            <StatusBarItem>
+                <Label x:Name="mouseTextureLabel" Content="Texture: N/A" Padding="0"/>
+            </StatusBarItem>
+            <Separator/>
+            <StatusBarItem>
+                <Label x:Name="mouseCollisionLabel" Content="Collision: N/A" Padding="0"/>
+            </StatusBarItem>
+        </StatusBar>
     </Grid>
 </Window>

--- a/RPGLevelEditor/RoomEditor.xaml.cs
+++ b/RPGLevelEditor/RoomEditor.xaml.cs
@@ -228,6 +228,27 @@ namespace RPGLevelEditor
             }
         }
 
+        private void tileMapScroll_MouseMove(object sender, MouseEventArgs e)
+        {
+            Point relativeMousePos = e.GetPosition(tileGridDisplay);
+            relativeMousePos = new Point(relativeMousePos.X / TileSize.X, relativeMousePos.Y / TileSize.Y);
+
+            mousePositionLabel.Content = $"Mouse: ({relativeMousePos.X:N2}, {relativeMousePos.Y:N2})";
+            gridPositionLabel.Content = $"Grid: ({(int)relativeMousePos.X:N0}, {(int)relativeMousePos.Y:N0})";
+
+            if (relativeMousePos.X >= 0 && relativeMousePos.X < OpenRoom.TileMap.GetLength(0)
+                && relativeMousePos.Y >= 0 && relativeMousePos.Y < OpenRoom.TileMap.GetLength(1))
+            {
+                mouseTextureLabel.Content = $"Texture: {OpenRoom.TileMap[(int)relativeMousePos.X, (int)relativeMousePos.Y].Texture}";
+                mouseCollisionLabel.Content = $"Collision: {OpenRoom.TileMap[(int)relativeMousePos.X, (int)relativeMousePos.Y].IsCollision}";
+            }
+            else
+            {
+                mouseTextureLabel.Content = "Texture: N/A";
+                mouseCollisionLabel.Content = "Collision: N/A";
+            }
+        }
+
         private void SaveItem_OnClick(object sender, RoutedEventArgs e)
         {
             Save();

--- a/RPGLevelEditor/RoomEditor.xaml.cs
+++ b/RPGLevelEditor/RoomEditor.xaml.cs
@@ -146,6 +146,7 @@ namespace RPGLevelEditor
                         Source = new BitmapImage(new Uri(texturePath)),
                         Stretch = Stretch.Fill
                     },
+                    ToolTip = textureName,
                     Tag = textureName
                 };
                 newElement.MouseUp += TextureSelect_MouseUp;

--- a/RPGLevelEditor/RoomEditor.xaml.cs
+++ b/RPGLevelEditor/RoomEditor.xaml.cs
@@ -116,12 +116,42 @@ namespace RPGLevelEditor
                         HorizontalAlignment = HorizontalAlignment.Left,
                         VerticalAlignment = VerticalAlignment.Top,
                         Stretch = Stretch.Fill,
+                        SnapsToDevicePixels = true,
                         Tag = gridPos
                     };
                     RenderOptions.SetBitmapScalingMode(newElement, BitmapScalingMode.NearestNeighbor);
                     newElement.MouseDown += GridSquare_MouseDown;
                     newElement.MouseEnter += GridSquare_MouseEnter;
                     _ = tileGridDisplay.Children.Add(newElement);
+                }
+            }
+
+            if (gridOverlayItem.IsChecked)
+            {
+                for (int x = 1; x < xSize; x++)
+                {
+                    _ = tileGridDisplay.Children.Add(new System.Windows.Shapes.Rectangle()
+                    {
+                        Height = tileGridDisplay.Height,
+                        Width = 3,
+                        Margin = new Thickness(x * TileSize.X - 1, 0, 0, 0),
+                        HorizontalAlignment = HorizontalAlignment.Left,
+                        VerticalAlignment = VerticalAlignment.Center,
+                        Fill = Brushes.DarkGoldenrod
+                    });
+                }
+
+                for (int y = 1; y < ySize; y++)
+                {
+                    _ = tileGridDisplay.Children.Add(new System.Windows.Shapes.Rectangle()
+                    {
+                        Height = 3,
+                        Width = tileGridDisplay.Width,
+                        Margin = new Thickness(0, y * TileSize.Y - 1, 0, 0),
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        VerticalAlignment = VerticalAlignment.Top,
+                        Fill = Brushes.DarkGoldenrod
+                    });
                 }
             }
         }
@@ -307,6 +337,11 @@ namespace RPGLevelEditor
         private void redoItem_OnClick(object sender, RoutedEventArgs e)
         {
             _ = Redo();
+        }
+
+        private void gridOverlayItem_OnClick(object sender, RoutedEventArgs e)
+        {
+            RefreshTileGrid();
         }
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)


### PR DESCRIPTION
Minor improvements for room editor usability.

* Status bar that shows information of tile under the mouse
* Showing the name of the texture when hovering over the selector panel
* Undo and redo menu items and keyboard shortcuts
* A toggle-able grid overlay

Closes #14, closes #17, closes #19, and closes #13 