### PR TITLE
Resize entities by dragging

### DIFF
--- a/RPGGame/GameObject/Entity/Entity.cs
+++ b/RPGGame/GameObject/Entity/Entity.cs
@@ -136,6 +136,11 @@ namespace RPGGame.GameObject.Entity
                 targetSize += Size;
             }
 
+            if (targetSize.X <= 0 || targetSize.Y <= 0)
+            {
+                return false;
+            }
+
             Vector2 originalSize = Size;
             Size = targetSize;
             if (IsOutOfBounds())

--- a/RPGGame/GameObject/Entity/Entity.cs
+++ b/RPGGame/GameObject/Entity/Entity.cs
@@ -24,6 +24,7 @@ namespace RPGGame.GameObject.Entity
     [FiresEvent("OnUnload", "Fired when the entity is loaded, before it runs its destroy logic")]
     [FiresEvent("OnDestroy", "Fired when the entity is loaded, after it runs its destroy logic")]
     [FiresEvent("OnMove", "Fired when the entity's position changes")]
+    [FiresEvent("OnResize", "Fired when the entity's size changes")]
     public class Entity(string name, Vector2 position, Vector2 size, string? texture) : ICloneable
     {
         [JsonProperty]
@@ -128,6 +129,25 @@ namespace RPGGame.GameObject.Entity
             return true;
         }
 
+        public virtual bool Resize(Vector2 targetSize, bool relative)
+        {
+            if (relative)
+            {
+                targetSize += Size;
+            }
+
+            Vector2 originalSize = Size;
+            Size = targetSize;
+            if (IsOutOfBounds())
+            {
+                Size = originalSize;
+                return false;
+            }
+
+            FireEvent("OnResize");
+            return true;
+        }
+
         public virtual object Clone()
         {
             return new Entity(Name, Position, Size, Texture);
@@ -221,6 +241,48 @@ namespace RPGGame.GameObject.Entity
                 return;
             }
             Move(position, true);
+        }
+
+        [ActionMethod("Sets the entity size to an absolute number of units. Class-specific resize logic applies")]
+        [ActionMethodParameter("TargetSize", "The absolute size to resize the entity to", typeof(Vector2), EditType.RoomCoordinate)]
+        protected void SetSize(Entity sender, Dictionary<string, object?> parameters)
+        {
+            if (!parameters.TryGetValue("TargetSize", out object? sizeObj) || sizeObj is not Vector2 size)
+            {
+                logger.LogError("TargetSize parameter for SetSize action was not given or was of incorrect type" +
+                    " (fired by \"{Source}\" to \"{Target}\")",
+                    sender.Name, Name);
+                return;
+            }
+            Resize(size, false);
+        }
+
+        [ActionMethod("Sets the entity size to a number of units relative to the current size. Class-specific resize logic applies")]
+        [ActionMethodParameter("ResizeVector", "The number of units in each dimension to affect the size by", typeof(Vector2), EditType.RoomCoordinate)]
+        protected void Resize(Entity sender, Dictionary<string, object?> parameters)
+        {
+            if (!parameters.TryGetValue("ResizeVector", out object? sizeObj) || sizeObj is not Vector2 size)
+            {
+                logger.LogError("ResizeVector parameter for Resize action was not given or was of incorrect type" +
+                    " (fired by \"{Source}\" to \"{Target}\")",
+                    sender.Name, Name);
+                return;
+            }
+            Resize(size, true);
+        }
+
+        [ActionMethod("Sets the entity size to a number of units relative to the current size with multipliers. Class-specific resize logic applies")]
+        [ActionMethodParameter("ScaleVector", "The multiplier in each dimension to affect the size by", typeof(Vector2), EditType.RoomCoordinate)]
+        protected void Scale(Entity sender, Dictionary<string, object?> parameters)
+        {
+            if (!parameters.TryGetValue("ScaleVector", out object? sizeObj) || sizeObj is not Vector2 scale)
+            {
+                logger.LogError("ScaleVector parameter for Scale action was not given or was of incorrect type" +
+                    " (fired by \"{Source}\" to \"{Target}\")",
+                    sender.Name, Name);
+                return;
+            }
+            Resize(Size * scale, false);
         }
 
         [ActionMethod("Sets the render texture of the entity")]

--- a/RPGGame/RPGGame.csproj
+++ b/RPGGame/RPGGame.csproj
@@ -40,8 +40,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/RPGLevelEditor/RoomEditor.xaml
+++ b/RPGLevelEditor/RoomEditor.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:RPGLevelEditor"
         mc:Ignorable="d"
-        Title="Room Editor" Height="900" Width="1620" Closing="Window_Closing" KeyDown="Window_KeyDown" Closed="Window_Closed" WindowState="Maximized" Icon="pack://application:,,,/Resources/MenuIcons/map--pencil.png">
+        Title="Room Editor" Height="900" Width="1620" Closing="Window_Closing" KeyDown="Window_KeyDown" PreviewKeyDown="Window_PreviewKeyDown" Closed="Window_Closed" WindowState="Maximized" Icon="pack://application:,,,/Resources/MenuIcons/map--pencil.png">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -112,10 +112,10 @@
                 <Rectangle HorizontalAlignment="Right" VerticalAlignment="Bottom" Fill="Magenta" Width="3" Height="{Binding ActualHeight, ElementName=tileGridDisplay, Mode=OneWay}" Margin="0,0,-3,0"/>
                 <Rectangle HorizontalAlignment="Right" VerticalAlignment="Bottom" Fill="Green" Width="{Binding ActualWidth, ElementName=tileGridDisplay, Mode=OneWay}" Height="3" Margin="0,0,0,-3"/>
                 <!-- Selected entity -->
-                <Grid x:Name="selectedEntityContainer" Cursor="SizeAll" MouseDown="selectedEntityContainer_MouseDown" MouseUp="selectedEntityContainer_MouseUp" MouseMove="selectedEntityContainer_MouseMove">
-                    <Image x:Name="selectedEntityImage" HorizontalAlignment="Left" VerticalAlignment="Top" Stretch="Fill" RenderOptions.BitmapScalingMode="NearestNeighbor"/>
-                    <Rectangle x:Name="selectedEntityBorder" HorizontalAlignment="Left" VerticalAlignment="Top" Stroke="Blue" StrokeThickness="2"/>
-                    <Ellipse x:Name="selectedEntityOrigin" HorizontalAlignment="Left" VerticalAlignment="Top" Fill="Red" Width="8" Height="8"/>
+                <Grid x:Name="selectedEntityContainer" MouseMove="tileGridDisplay_MouseMove" MouseUp="tileGridDisplay_MouseUp">
+                    <Image x:Name="selectedEntityImage" HorizontalAlignment="Left" VerticalAlignment="Top" Stretch="Fill" RenderOptions.BitmapScalingMode="NearestNeighbor" Cursor="SizeAll" MouseDown="selectedEntityImage_MouseDown" MouseMove="tileGridDisplay_MouseMove" MouseUp="tileGridDisplay_MouseUp"/>
+                    <Rectangle x:Name="selectedEntityBorder" HorizontalAlignment="Left" VerticalAlignment="Top" Stroke="Blue" StrokeThickness="2" MouseDown="selectedEntityBorder_MouseDown" MouseMove="tileGridDisplay_MouseMove" MouseUp="tileGridDisplay_MouseUp"/>
+                    <Ellipse x:Name="selectedEntityOrigin" HorizontalAlignment="Left" VerticalAlignment="Top" Fill="Red" Width="8" Height="8" MouseMove="tileGridDisplay_MouseMove" MouseUp="tileGridDisplay_MouseUp"/>
                 </Grid>
                 <Canvas x:Name="entityNetworkCanvas" IsHitTestVisible="False"/>
             </Grid>

--- a/RPGLevelEditor/RoomEditor.xaml.cs
+++ b/RPGLevelEditor/RoomEditor.xaml.cs
@@ -1176,7 +1176,6 @@ namespace RPGLevelEditor
             Microsoft.Xna.Framework.Vector2 oldPos = selectedEntity.Position;
             float originalRatio = oldSize.X / oldSize.Y;
 
-
             Microsoft.Xna.Framework.Vector2 newSize = oldSize;
             Microsoft.Xna.Framework.Vector2 newPos = oldPos;
 
@@ -1192,7 +1191,7 @@ namespace RPGLevelEditor
                     newSize.X = (float)Math.Abs(dragStartSize.X + ((mousePos.X - dragStartOffset.X) * 2));
                 }
             }
-            if (!Keyboard.Modifiers.HasFlag(ModifierKeys.Alt))
+            else
             {
                 // Adjust position to move only selected edge
                 // (new position is calculated later after potential modifications to final size have been made)

--- a/RPGLevelEditor/RoomEditorStateStack.cs
+++ b/RPGLevelEditor/RoomEditorStateStack.cs
@@ -49,6 +49,26 @@ namespace RPGLevelEditor
             }
         }
 
+        private class EntityResizeStackFrame(RoomEditor editorWindow, Entity entity, float x, float y, float w, float h) : StateStackFrame(editorWindow)
+        {
+            public Entity Entity { get; } = entity;
+            public float X { get; } = x;
+            public float Y { get; } = y;
+            public float Width { get; } = w;
+            public float Height { get; } = h;
+
+            public override void RestoreState(bool isUndo)
+            {
+                Stack<StateStackFrame> stack = isUndo ? EditorWindow.redoStack : EditorWindow.undoStack;
+                stack.Push(new EntityResizeStackFrame(EditorWindow, Entity, Entity.Position.X, Entity.Position.Y, Entity.Size.X, Entity.Size.Y));
+
+                EditorWindow.DrawEntity(Entity, true);
+                _ = Entity.Move(new Microsoft.Xna.Framework.Vector2(X, Y), false);
+                _ = Entity.Resize(new Microsoft.Xna.Framework.Vector2(Width, Height), false);
+                EditorWindow.SelectEntity(Entity);
+            }
+        }
+
         private class EntityCreateStackFrame(RoomEditor editorWindow, float x, float y) : StateStackFrame(editorWindow)
         {
             public float X { get; } = x;


### PR DESCRIPTION
## Modifier Keys (can be combined)

- CTRL: Maintain aspect ratio
- Alt: Don't change position (only affects horizontal resizing - effectively makes it symmetrical)
- Shift: Snap to grid boundaries

https://github.com/user-attachments/assets/59ea9438-2b61-43af-80e4-c34e8bb7f759
